### PR TITLE
Support LDIF files containing more than one entry and at least one modification

### DIFF
--- a/src/test/java/com/github/kwart/ldap/LdapServer2Test.java
+++ b/src/test/java/com/github/kwart/ldap/LdapServer2Test.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package com.github.kwart.ldap;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.junit.Test;
+
+
+public class LdapServer2Test {
+
+    @Test
+    public void testLoadLdifWithModificationAndEntries() throws Exception {
+        Path tempLdif = Files.createTempFile("modify_new_entries", ".ldif");
+        try (InputStream testData = LdapServer2Test.class.
+                getResourceAsStream("/modify_new_entries.ldif")) {
+            Files.copy(testData, tempLdif, StandardCopyOption.REPLACE_EXISTING);
+        }
+        try {
+            CLIArguments cliArguments = new CLIArguments();
+            String[] args = new String[]{tempLdif.toAbsolutePath().toString()};
+            new ExtCommander(cliArguments, args);
+            new LdapServer(cliArguments).stop();
+        } finally {
+            Files.delete(tempLdif);
+        }
+    }
+}

--- a/src/test/resources/modify_new_entries.ldif
+++ b/src/test/resources/modify_new_entries.ldif
@@ -1,0 +1,27 @@
+dn: cn=nis,ou=schema
+changetype: modify
+replace: m-disabled
+m-disabled: FALSE
+-
+
+dn: m-oid=1.2.840.113556.1.4.222, ou=attributetypes, cn=nis,ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.2.840.113556.1.4.222
+m-name: memberOf
+m-equality: caseIgnoreMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+m-singleValue: FALSE
+
+dn: m-oid=1.2.3.4.56789.1.0.200,ou=objectClasses,cn=nis,ou=schema
+m-may: memberOf
+m-typeobjectclass: AUXILIARY
+m-supobjectclass: top
+m-description: dummy
+m-oid: 1.2.3.4.56789.1.0.200
+m-name: groupMemberShip
+objectclass: metaObjectClass
+objectclass: metaTop
+objectclass: top
+


### PR DESCRIPTION
Currently ldap-server requires multiple LDIF files if an entry contains a changetype entry and does not properly apply modifications.

One use-case is: Enable a build-in schema, add attribute types and sample data.

It was tested with `ldapadd`, which happily accepted this case and applied the changes, while ldap-server rejected them:

```
[main] ERROR org.apache.directory.api.ldap.model.ldif.LdifReader - ERR_12004_CHANGE_NOT_ALLOWED We cannot have changes when reading a file which already contains entries, at line 6 [main] ERROR org.apache.directory.api.ldap.model.ldif.LdifReader - ERR_12005_NO_CHANGE No changes within entries Exception in thread "main" java.lang.NullPointerException: Cannot invoke "org.apache.directory.api.ldap.model.ldif.LdifEntry.getDn()" because "ldifEntry" is null
        at com.github.kwart.ldap.LdapServer.checkPartition(LdapServer.java:184)
        at com.github.kwart.ldap.LdapServer.importLdif(LdapServer.java:173)
        at com.github.kwart.ldap.LdapServer.importLdif(LdapServer.java:165)
        at com.github.kwart.ldap.LdapServer.<init>(LdapServer.java:97)
        at com.github.kwart.ldap.LdapServer.main(LdapServer.java:76)
```